### PR TITLE
Add GitHub icon to link the website to the repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
   )
 Description: Plots for the 'TILT' project.
 License: MIT + file LICENSE
-URL: https://2degreesinvesting.github.io/tiltPlot/
+URL: https://2degreesinvesting.github.io/tiltPlot/, https://github.com/2DegreesInvesting/tiltPlot
 Depends: 
     R (>= 2.10)
 Imports: 
@@ -28,3 +28,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+BugReports: https://github.com/2DegreesInvesting/tiltPlot/issues


### PR DESCRIPTION
This PR adds a GitHub icon to the top-right of the website. This allows the user to navigate from the website to the repo.

FYI to do this I run `use_github_links(overwrite = TRUE)`

NOW

![image](https://github.com/2DegreesInvesting/tiltPlot/assets/5856545/57f32b23-1283-4aa4-afe2-f8f551242a14)


BEFORE

![image](https://github.com/2DegreesInvesting/tiltPlot/assets/5856545/18c6c9e8-729a-4623-b3d0-a83e113eb447)

----

TODO

- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
