### PR TITLE
Add installation instructions with pak

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,18 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/2DegreesInvesting/tiltPlot/branch/main/graph/badge.svg)](https://app.codecov.io/gh/2DegreesInvesting/tiltPlot?branch=main)
 <!-- badges: end -->
 
-The goal of tiltPlot is to provide plots for the TILT project. 
+The goal of tiltPlot is to provide plots for the TILT project.
+
+## Installation
+
+You can install the development version of tiltPlot from GitHub with:
+
+```r
+# install.packages("pak")
+pak::pak("2DegreesInvesting/tiltPlot")
+```
+
+## Example
 
 ```{r}
 library(ggplot2)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ coverage](https://codecov.io/gh/2DegreesInvesting/tiltPlot/branch/main/graph/bad
 
 The goal of tiltPlot is to provide plots for the TILT project.
 
+## Installation
+
+You can install the development version of tiltPlot from GitHub with:
+
+``` r
+# install.packages("pak")
+pak::pak("2DegreesInvesting/tiltPlot")
+```
+
+## Example
+
 ``` r
 library(ggplot2)
 library(dplyr)
@@ -146,8 +157,8 @@ To plot on a company level:
 ``` r
 no_fin <- without_financial
 
-no_fin |> 
-  filter(company_name == "peter") |> 
+no_fin |>
+  filter(company_name == "peter") |>
   plot_xctr() +
   labs(title = "Risk distribution of all products on a company level")
 ```


### PR DESCRIPTION
Relates to #69 

This issue adds installation instructions with pak. The installation instructions were missing, and pak is important to ensure the system dependencies are installed smoothly.

----

TODO

- [x] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
