### PR TITLE
Ignore Rplots.pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .Rproj.user
 docs
+Rplots.pdf


### PR DESCRIPTION
This PR ignores the annoying file Rplots.pdf, which is an artifact
of running examples. Ideally, examples should not write to disk (CRAN
prohibits it) but for nowignoring it feels like a small improvement.


----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [ ] Describe the goal of the PR. Avoid details that are clear in the diff.
- [ ] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [ ] Review your own PR in "Files changed".
- [ ] Ensure the PR branch is updated.
- [ ] Ensure the checks pass.
- [ ] Change the status from draft to ready.
- [ ] Polish the PR title and description.
- [ ] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
