### PR TITLE
Update pr checklist to remind updating the changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+
+
 ----
 
 TODO
@@ -10,9 +12,7 @@ TODO
 - [ ] Ensure the PR branch is updated.
 - [ ] Ensure the checks pass.
 - [ ] Change the status from draft to ready.
-- [ ] Polish the PR title and description.
+- [ ] Polish the PR description to reflect what it ended up doing.
+- [ ] Polish the PR title as you'd like others to read it from the git log.
 - [ ] Assign a reviewer.
-
-EXCEPTIONS
-
-- [ ] Slide here any item that you intentionally choose to not do.
+- [ ] Document user-facing changes in the changelog.


### PR DESCRIPTION
The changelog is becoming more important as our packages gradually gain more visibility -- to other developers as we increasingly collaborate, and to Deloitte team as we report our monthly progress during the dev-cycle meetings. 

I edit the changelog with [fledge](https://fledge.cynkra.com/) but it's also easy to do manually:

- Edit NEWS.md
- Increment the version number in DESCRIPTION
- Tag the commit with the new version with something like:

```bash
git tag -a <version> -m "Some message"
git push origin <version>
```


----

TODO

- [ ] [Link related issue/PR]([url](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). 
- [x] Describe the goal of the PR. Avoid details that are clear in the diff.
- [x] Mark the PR as draft.
- [ ] [Include a unit test](https://code-review.tidyverse.org/reviewer/aspects.html#sec-tests).
- [x] Review your own PR in "Files changed".
- [x] Ensure the PR branch is updated.
- [x] Ensure the checks pass.
- [x] Change the status from draft to ready.
- [x] Polish the PR title and description.
- [x] Assign a reviewer.

EXCEPTIONS

- [ ] Slide here any item that you intentionally choose to not do.
